### PR TITLE
feature: display timeline by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The format of the task list items is important as this is what is used to calcul
 
 ### Timeline View
 
-The `Show the Day Planner Timeline` command can be used to add a vertical timeline view to show the tasks for today's plan and a line marking the current time.
+The `Show timeline` command can be used to add a vertical timeline view to show the tasks for today's plan and a line marking the current time.
 
 ![Day Planner Timeline](https://raw.githubusercontent.com/jdbeightol/obsidian-simple-day-planner/main/images/day-planner-timeline.png)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-simple-day-planner",
   "name": "Simple Day Planner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A plugin to help you plan your day —simply!",
   "isDesktopOnly": false,
   "js": "main.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-simple-day-planner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-simple-day-planner",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "obsidian-daily-notes-interface": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-simple-day-planner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A plugin to help you plan your day —simply!",
   "main": "main.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,8 +58,7 @@ export default class DayPlanner extends Plugin {
         );
 
         this.addSettingTab(new DayPlannerSettingsTab(this.app, this));
-        this.registerInterval(
-        window.setInterval(async () => {
+        this.registerInterval(window.setInterval(async () => {
             try {
                 if(this.file.hasTodayNote()){
                     // console.log('Active note found, starting file processing')
@@ -72,6 +71,12 @@ export default class DayPlanner extends Plugin {
                 console.log(error)
             }
         }, 2000));
+
+        if (this.app.workspace.layoutReady) {
+            this.initLeaf();
+        } else {
+            this.app.workspace.onLayoutReady(() => this.initLeaf());
+        }
     }
 
     initLeaf() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ export default class DayPlanner extends Plugin {
 
         this.addCommand({
             id: 'app:show-day-planner-timeline',
-            name: 'Show the Simple Day Planner Timeline',
+            name: 'Show timeline',
             callback: () => this.initLeaf(),
             hotkeys: []
         });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,9 +59,4 @@ export default class Parser {
         });
         return results;
     }
-
-    private matchValue(input: any, match: string): boolean {
-        return input?.trim().toLocaleLowerCase() === match;
-    }
-
 }

--- a/src/planner-md.ts
+++ b/src/planner-md.ts
@@ -13,7 +13,7 @@ export default class PlannerMarkdown {
     parser: Parser;
     progress: Progress;
     noteForDateQuery: NoteForDateQuery;
-    
+
     constructor(workspace: Workspace, settings: DayPlannerSettings, file: DayPlannerFile, parser: Parser, progress: Progress){
         this.workspace = workspace;
         this.settings = settings;
@@ -22,7 +22,7 @@ export default class PlannerMarkdown {
         this.progress = progress;
         this.noteForDateQuery = new NoteForDateQuery();
     }
-    
+
     async parseDayPlanner():Promise<PlanSummaryData> {
         try {
             const fileContent = await (await this.file.getFileContents()).split('\n');

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -66,13 +66,4 @@ export class DayPlannerSettingsTab extends PluginSettingTab {
                 this.plugin.saveData(this.plugin.settings);
                 }));
     }
-
-    private addDocsLink(descEl: DocumentFragment) {
-        const a = document.createElement('a');
-        a.href = 'https://github.com/jdbeightol/obsidian-simple-day-planner/blob/main/README.md';
-        a.text = 'plugin README';
-        a.target = '_blank';
-        descEl.appendChild(a);
-        descEl.appendChild(document.createElement('br'));
-    }
 }


### PR DESCRIPTION
This work displays the timeline pane by default when loading Obsidian or the plugin as per the default behavior of other common Obsidian plugins.

Closes #4